### PR TITLE
[Add] 낙관적 락을 통한 동시성 문제 해결 

### DIFF
--- a/src/main/java/couponToy/CouponToyProject/Coupon/model/Coupon.java
+++ b/src/main/java/couponToy/CouponToyProject/Coupon/model/Coupon.java
@@ -10,12 +10,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Entity
 @Table(name = "coupons")
 @SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Coupon extends BaseTimeEntity {
 
     @Id
@@ -30,6 +30,10 @@ public class Coupon extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer issuedCount = 0;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
 
     public void increaseIssueAmount() {
         if (issuedCount >= totalCount) {

--- a/src/main/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponService.java
+++ b/src/main/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponService.java
@@ -8,6 +8,7 @@ import couponToy.CouponToyProject.CouponIssue.model.IssueCoupon;
 import couponToy.CouponToyProject.CouponIssue.repository.IssueCouponRepository;
 import couponToy.CouponToyProject.Member.model.Member;
 import couponToy.CouponToyProject.Member.repository.MemberRepository;
+import couponToy.CouponToyProject.global.aop.annotation.Retry;
 import couponToy.CouponToyProject.global.constant.ErrorCode;
 import couponToy.CouponToyProject.global.exception.CouponNotFoundException;
 import couponToy.CouponToyProject.global.exception.MemberNotFoundException;
@@ -24,6 +25,7 @@ public class IssueCouponService {
     private final MemberRepository memberRepository;
     private final CouponRepository couponRepository;
 
+    @Retry
     @Transactional
     public IssueCouponResponse issueCoupon(IssueCouponRequest issueCouponRequest, MemberDetails memberDetails, Long couponId) {
         Member member = memberRepository.findById(memberDetails.getMemberId()).orElseThrow(

--- a/src/main/java/couponToy/CouponToyProject/global/aop/annotation/Retry.java
+++ b/src/main/java/couponToy/CouponToyProject/global/aop/annotation/Retry.java
@@ -1,0 +1,11 @@
+package couponToy.CouponToyProject.global.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Retry {
+}

--- a/src/main/java/couponToy/CouponToyProject/global/aop/aspect/OptimisticLockRetryAspect.java
+++ b/src/main/java/couponToy/CouponToyProject/global/aop/aspect/OptimisticLockRetryAspect.java
@@ -1,0 +1,40 @@
+package couponToy.CouponToyProject.global.aop.aspect;
+
+import jakarta.persistence.OptimisticLockException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.hibernate.StaleObjectStateException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@Aspect
+@Component
+public class OptimisticLockRetryAspect {
+
+    private static final int MAX_RETRIES = 1000;
+    private static final int RETRY_DELAY_MS = 100;
+
+    @Pointcut("@annotation(couponToy.CouponToyProject.global.aop.annotation.Retry)")
+    public void retry() {
+    }
+
+    @Around("retry()")
+    public Object retryOptimisticLock(ProceedingJoinPoint joinPoint) throws Throwable {
+        Exception exceptionHolder = null;
+
+        for (int attempt = 0; attempt < MAX_RETRIES; attempt++) {
+            try {
+                return joinPoint.proceed();
+            } catch (OptimisticLockException | ObjectOptimisticLockingFailureException | StaleObjectStateException e) {
+                exceptionHolder = e;
+                Thread.sleep(RETRY_DELAY_MS);
+            }
+        }
+        throw exceptionHolder;
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/global/exception/CouponNotFoundException.java
+++ b/src/main/java/couponToy/CouponToyProject/global/exception/CouponNotFoundException.java
@@ -4,10 +4,7 @@ import couponToy.CouponToyProject.global.constant.ErrorCode;
 
 public class CouponNotFoundException extends BaseException{
 
-    private final ErrorCode errorCode;
-
     public CouponNotFoundException(ErrorCode errorCode) {
         super(errorCode);
-        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/couponToy/CouponToyProject/global/exception/CouponSoldOutException.java
+++ b/src/main/java/couponToy/CouponToyProject/global/exception/CouponSoldOutException.java
@@ -4,10 +4,7 @@ import couponToy.CouponToyProject.global.constant.ErrorCode;
 
 public class CouponSoldOutException extends RuntimeException{
 
-    private final ErrorCode errorCode;
-
     public CouponSoldOutException (ErrorCode errorCode) {
         super(errorCode.getMessage());
-        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/couponToy/CouponToyProject/global/exception/DuplicateMemberException.java
+++ b/src/main/java/couponToy/CouponToyProject/global/exception/DuplicateMemberException.java
@@ -4,11 +4,8 @@ import couponToy.CouponToyProject.global.constant.ErrorCode;
 
 public class DuplicateMemberException extends BaseException {
 
-    private ErrorCode errorCode;
-
     public DuplicateMemberException(ErrorCode errorCode) {
         super(errorCode);
-        this.errorCode = errorCode;
     }
 }
 

--- a/src/test/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponServiceTest.java
+++ b/src/test/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponServiceTest.java
@@ -161,10 +161,10 @@ public class IssueCouponServiceTest {
 
 
     @Test
-    @DisplayName("서로 다른 30명의 사용자가 동시에 10장 쿠폰 발급 시도 실패")
+    @DisplayName("서로 다른 30명의 사용자가 동시에 10장 쿠폰 발급 시도 성공")
     void issuedConcurrencyTest_concurrent() throws InterruptedException {
         // given
-        int threadCount = 30;
+        int threadCount = 15;
         int couponAmount = 10;
 
         Coupon coupon = createTestCoupon(couponAmount);
@@ -203,12 +203,15 @@ public class IssueCouponServiceTest {
 
         // then
         long issuedCoupons = issueCouponRepository.countByCouponId(coupon.getCouponId());
+        long expectedFailCount = Math.max(0, issuedCoupons - couponAmount);
 
         System.out.println("발급 성공 : " + successCount.get());
         System.out.println("발급 실패 : " + failCount.get());
         System.out.println("총 발급 : " + issuedCoupons);
 
-        assertThat(issuedCoupons).isLessThan(threadCount);
-        assertThat(issuedCoupons).isLessThan(couponAmount);
+        assertThat(issuedCoupons).isEqualTo(couponAmount); // 딱 정해진 수만큼 발급되어야 함
+        assertThat(successCount.get()).isEqualTo((int) issuedCoupons);
+        assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount);
+        assertThat(failCount.get()).isEqualTo(threadCount - couponAmount);
     }
 }

--- a/src/test/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponServiceTest.java
+++ b/src/test/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponServiceTest.java
@@ -104,6 +104,7 @@ public class IssueCouponServiceTest {
         return couponRepository.findById(createdCoupon.getCouponId()).orElseThrow();
     }
 
+
     @Test
     @DisplayName("쿠폰 생성 테스트")
     @Transactional
@@ -124,8 +125,9 @@ public class IssueCouponServiceTest {
         assertThat(issueCoupon.getMemberId()).isEqualTo(member.getMemberId());
     }
 
+
     @Test
-    @DisplayName("쿠폰 순차적 발급 테스트")
+    @DisplayName("동일 유저 쿠폰 순차적 발급 테스트")
     @Transactional
     void issuedConcurrencyTest() {
         // given
@@ -134,6 +136,7 @@ public class IssueCouponServiceTest {
 
         Coupon coupon = createTestCoupon(couponAmount);
         Member member = createTestMember();
+
         AtomicInteger successCount = new AtomicInteger();
         AtomicInteger failCount = new AtomicInteger();
 
@@ -161,10 +164,51 @@ public class IssueCouponServiceTest {
 
 
     @Test
+    @DisplayName("여러 유저 쿠폰 순차적 발급 테스트")
+    @Transactional
+    void issuedSequentialTest() {
+        // given
+        int memberCount = 10;
+        int couponAmount = 5;
+
+        Coupon coupon = createTestCoupon(couponAmount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < memberCount; i++) {
+            try {
+                Member member = createMultiTestMember(i);
+
+                IssueCouponRequest request = new IssueCouponRequest(member.getMemberId(), coupon.getCouponId());
+                issueCouponService.issueCoupon(request,
+                        (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal(),
+                        coupon.getCouponId());
+
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            }
+        }
+
+        System.out.println("successCount = " + successCount);
+        System.out.println("failCount = " + failCount);
+
+        // then
+        long issuedCoupons = issueCouponRepository.countByCouponId(coupon.getCouponId());
+
+        assertThat(issuedCoupons).isEqualTo(couponAmount);
+        assertThat(failCount.get()).isEqualTo(memberCount - issuedCoupons);
+    }
+
+
+
+    @Test
     @DisplayName("서로 다른 30명의 사용자가 동시에 10장 쿠폰 발급 시도 성공")
     void issuedConcurrencyTest_concurrent() throws InterruptedException {
         // given
-        int threadCount = 15;
+        int threadCount = 30;
         int couponAmount = 10;
 
         Coupon coupon = createTestCoupon(couponAmount);
@@ -205,9 +249,9 @@ public class IssueCouponServiceTest {
         long issuedCoupons = issueCouponRepository.countByCouponId(coupon.getCouponId());
         long expectedFailCount = Math.max(0, issuedCoupons - couponAmount);
 
-        System.out.println("발급 성공 : " + successCount.get());
-        System.out.println("발급 실패 : " + failCount.get());
-        System.out.println("총 발급 : " + issuedCoupons);
+        System.out.println("successCount : " + successCount.get());
+        System.out.println("failCount : " + failCount.get());
+        System.out.println("issuedCount : " + issuedCoupons);
 
         assertThat(issuedCoupons).isEqualTo(couponAmount); // 딱 정해진 수만큼 발급되어야 함
         assertThat(successCount.get()).isEqualTo((int) issuedCoupons);


### PR DESCRIPTION
## 작업 요약
- 동시성 문제 해결을 위해 낙관적 락 사용
- coupons 테이블에 version 컬럼 추가
- 락 획득 실패 시 재시도 로직 AOP 사용하여 구현
## Issue Link
#20 
## 문제점 및 어려움
- 낙관적 락 사용 시 요청 순서대로 처리하지 못 함
## 해결 방안
- 비관적 락 사용 필요
## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 쿠폰 발행 시 자동 재시도 메커니즘을 도입하여, 일시적인 오류 발생 시에도 원활한 처리가 가능해졌습니다.
	- 동시성 제어 기능이 강화되어 쿠폰 발행 과정의 신뢰성이 향상되었습니다.
- **리팩터**
	- 관련 예외 처리 로직을 간소화하여, 오류 메시지 전달이 보다 명확해졌습니다.
- **테스트**
	- 다양한 쿠폰 발행 시나리오를 검증하는 테스트 케이스가 추가되어 전반적인 기능 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->