### PR TITLE
feat : Redis sorted set을 활용한 대기열 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.awaitility:awaitility:4.3.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-crypto:6.4.2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/couponToy/CouponToyProject/CouponIssue/model/IssueCoupon.java
+++ b/src/main/java/couponToy/CouponToyProject/CouponIssue/model/IssueCoupon.java
@@ -24,17 +24,8 @@ public class IssueCoupon extends BaseTimeEntity {
 
     private Long couponId;
 
-//    @ManyToOne
-//    @JoinColumn(name = "member_id")
-//    private Member member;
-//
-//    @ManyToOne
-//    @JoinColumn(name = "coupon_id")
-//    private Coupon coupon;
-
     public IssueCoupon(Member member, Coupon coupon) {
         this.memberId = member.getMemberId();
         this.couponId = coupon.getCouponId();
     }
-
 }

--- a/src/main/java/couponToy/CouponToyProject/CouponIssue/repository/IssueCouponRepository.java
+++ b/src/main/java/couponToy/CouponToyProject/CouponIssue/repository/IssueCouponRepository.java
@@ -6,6 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IssueCouponRepository extends JpaRepository<IssueCoupon, Long> {
-//    long countByCoupon_CouponId(Long couponId);
     long countByCouponId(Long couponId);
 }

--- a/src/main/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponService.java
+++ b/src/main/java/couponToy/CouponToyProject/CouponIssue/service/IssueCouponService.java
@@ -13,11 +13,9 @@ import couponToy.CouponToyProject.global.exception.CouponNotFoundException;
 import couponToy.CouponToyProject.global.exception.MemberNotFoundException;
 import couponToy.CouponToyProject.global.security.MemberDetails;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class IssueCouponService {
@@ -40,25 +38,6 @@ public class IssueCouponService {
         IssueCoupon issueCoupon = issueCouponRepository.save(issueCouponRequest.toEntity(member, coupon));
 
         return IssueCouponResponse.fromEntity(issueCoupon);
-    }
-
-
-    @Transactional
-    public void issueFromQueue(Long couponId, Long userId) {
-        // 1. 쿠폰을 비관적 락으로 조회
-        Coupon coupon = couponRepository.findByCouponIdForUpdate(couponId)
-                .orElseThrow(() -> new CouponNotFoundException(ErrorCode.NOT_FOUND_COUPON));
-
-        // 2. 발급 수량 초과 여부 확인 & 발급 수량 증가
-        coupon.increaseIssueAmount();
-
-        // 3. 발급 이력 저장
-        IssueCoupon issueCoupon = IssueCoupon.builder()
-                .memberId(userId)
-                .couponId(couponId)
-                .build();
-
-        issueCouponRepository.save(issueCoupon);
     }
 }
 

--- a/src/main/java/couponToy/CouponToyProject/global/config/RedisConfig.java
+++ b/src/main/java/couponToy/CouponToyProject/global/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package couponToy.CouponToyProject.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/global/constant/ErrorCode.java
+++ b/src/main/java/couponToy/CouponToyProject/global/constant/ErrorCode.java
@@ -32,7 +32,11 @@ public enum ErrorCode {
 
     // Coupon
     NOT_FOUND_COUPON("일치하는 쿠폰정보가 없습니다. 쿠폰 번호를 확인해주세요"),
-    COUPON_SOLD_OUT("쿠폰이 모두 소진되었습니다.");
+    COUPON_SOLD_OUT("쿠폰이 모두 소진되었습니다."),
+
+
+    // Queue
+    IS_ALREADY_ISSUED("이미 쿠폰 발급 받은 사용자입니다.");
 
     private final String message;
 }

--- a/src/main/java/couponToy/CouponToyProject/global/exception/IsAlreadyIssued.java
+++ b/src/main/java/couponToy/CouponToyProject/global/exception/IsAlreadyIssued.java
@@ -1,0 +1,9 @@
+package couponToy.CouponToyProject.global.exception;
+
+import couponToy.CouponToyProject.global.constant.ErrorCode;
+
+public class IsAlreadyIssued extends BaseException{
+    public IsAlreadyIssued(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/queue/controller/CouponQueueController.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/controller/CouponQueueController.java
@@ -4,6 +4,7 @@ import couponToy.CouponToyProject.global.api.ApiUtils;
 import couponToy.CouponToyProject.global.security.MemberDetails;
 import couponToy.CouponToyProject.queue.service.CouponQueueService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,8 +29,12 @@ public class CouponQueueController {
         couponQueueService.registerUser(couponId, userId);
         Long rank = couponQueueService.getUserRank(couponId, userId);
 
-        return ResponseEntity.ok(
-                ApiUtils.success("쿠폰 발급 요청 완료. 현재 대기 순번: " + (rank + 1))
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(
+                    ApiUtils.success(
+                            "쿠폰 발급 요청 완료. 현재 대기 순번: " + (rank + 1)
+                    )
         );
     }
 
@@ -44,6 +49,7 @@ public class CouponQueueController {
         Long userId = memberDetails.getMemberId();
 
         boolean issued = couponQueueService.isAlreadyIssued(couponId, userId);
+
         return ResponseEntity.ok(
                 ApiUtils.success(issued ? "쿠폰 발급 완료됨" : "아직 미발급")
         );

--- a/src/main/java/couponToy/CouponToyProject/queue/controller/CouponQueueController.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/controller/CouponQueueController.java
@@ -1,0 +1,51 @@
+package couponToy.CouponToyProject.queue.controller;
+
+import couponToy.CouponToyProject.global.api.ApiUtils;
+import couponToy.CouponToyProject.global.security.MemberDetails;
+import couponToy.CouponToyProject.queue.service.CouponQueueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/queue")
+@RequiredArgsConstructor
+public class CouponQueueController {
+
+    private final CouponQueueService couponQueueService;
+
+    /**
+     * 쿠폰 발급 요청 → Redis 큐에 등록
+     */
+    @PostMapping("/coupon/{couponId}")
+    public ResponseEntity<?> registerCouponQueue(
+            @PathVariable Long couponId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Long userId = memberDetails.getMemberId();
+
+        couponQueueService.registerUser(couponId, userId);
+        Long rank = couponQueueService.getUserRank(couponId, userId);
+
+        return ResponseEntity.ok(
+                ApiUtils.success("쿠폰 발급 요청 완료. 현재 대기 순번: " + (rank + 1))
+        );
+    }
+
+    /**
+     * 사용자 발급 여부 확인
+     */
+    @GetMapping("/coupon/{couponId}/status")
+    public ResponseEntity<?> checkIssued(
+            @PathVariable Long couponId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Long userId = memberDetails.getMemberId();
+
+        boolean issued = couponQueueService.isAlreadyIssued(couponId, userId);
+        return ResponseEntity.ok(
+                ApiUtils.success(issued ? "쿠폰 발급 완료됨" : "아직 미발급")
+        );
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
@@ -1,11 +1,13 @@
 package couponToy.CouponToyProject.queue.repository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Set;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class CouponQueueRepository {
@@ -53,7 +55,7 @@ public class CouponQueueRepository {
         String key = buildIssuedKey(couponId);
         Double score = redisTemplate.opsForZSet().score(key, String.valueOf(userId));
 
-        System.out.println("check issued - userId: " + userId + ", score: " + score);
+        log.debug("check issued - userId: {}, score: {}", userId, score);
 
         return score != null;
     }

--- a/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
@@ -1,0 +1,60 @@
+package couponToy.CouponToyProject.queue.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponQueueRepository {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String WAITING_KEY_PREFIX = "coupon:waiting:";
+    private static final String ISSUED_KEY_PREFIX = "coupon:issued:";
+
+    public String buildQueueKey(Long couponId) {
+        return WAITING_KEY_PREFIX + couponId;
+    }
+
+    private String buildIssuedKey(Long couponId) {
+        return ISSUED_KEY_PREFIX + couponId;
+    }
+
+    public void addToWaitingQueue(Long couponId, Long userId) {
+        String key = buildQueueKey(couponId);
+        double score = System.currentTimeMillis();
+        redisTemplate.opsForZSet().add(key, String.valueOf(userId), score);
+    }
+
+    public Long getUserRank(Long couponId, Long userId) {
+        String key = buildQueueKey(couponId);
+        return redisTemplate.opsForZSet().rank(key, String.valueOf(userId));
+    }
+
+    public Set<String> getTopNUsers(Long couponId, Long count) {
+        String key = buildQueueKey(couponId);
+        return redisTemplate.opsForZSet().range(key, 0, count - 1);
+    }
+
+    public void removeUserFromQueue(Long couponId, Long userId) {
+        String key = buildQueueKey(couponId);
+        redisTemplate.opsForZSet().remove(key, String.valueOf(userId));
+    }
+
+    public void addToIssuedSet(Long couponId, Long userId) {
+        String key = buildIssuedKey(couponId);
+        redisTemplate.opsForZSet().add(key, String.valueOf(userId), System.currentTimeMillis());
+    }
+
+    public boolean isAlreadyIssued(Long couponId, Long userId) {
+        String key = buildIssuedKey(couponId);
+        return redisTemplate.opsForZSet().score(key, String.valueOf(userId)) != null;
+    }
+
+    public Long getQueueSize(Long couponId) {
+        String key = buildQueueKey(couponId);
+        return redisTemplate.opsForZSet().size(key);
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
@@ -15,6 +15,7 @@ public class CouponQueueRepository {
     private final StringRedisTemplate redisTemplate;
     private static final String WAITING_KEY_PREFIX = "coupon:waiting:";
     private static final String ISSUED_KEY_PREFIX = "coupon:issued:";
+    private static final String FAILED_KEY_PREFIX = "coupon:failed:";
 
 
     public String buildQueueKey(Long couponId) {
@@ -25,31 +26,65 @@ public class CouponQueueRepository {
         return ISSUED_KEY_PREFIX + couponId;
     }
 
+    private String buildFailedKey(Long couponId) {
+        return FAILED_KEY_PREFIX + couponId;
+    }
+
     public void addToWaitingQueue(Long couponId, Long userId) {
         String key = buildQueueKey(couponId);
         double score = System.currentTimeMillis();
         redisTemplate.opsForZSet().add(key, String.valueOf(userId), score);
     }
 
+
+    public void addToFailedQueue(Long couponId, Long userId) {
+        String key = buildFailedKey(couponId);
+        double score = System.currentTimeMillis();
+        redisTemplate.opsForZSet().add(key, String.valueOf(userId), score);
+    }
+
+
     public Long getUserRank(Long couponId, Long userId) {
         String key = buildQueueKey(couponId);
         return redisTemplate.opsForZSet().rank(key, String.valueOf(userId));
     }
+
 
     public Set<String> getTopNUsers(Long couponId, Long count) {
         String key = buildQueueKey(couponId);
         return redisTemplate.opsForZSet().range(key, 0, count - 1);
     }
 
+
+    public Set<String> getTopFailedNUsers(Long couponId, Long count) {
+        String key = buildFailedKey(couponId);
+        return redisTemplate.opsForZSet().range(key, 0, count - 1);
+    }
+
+
     public void removeUserFromQueue(Long couponId, Long userId) {
         String key = buildQueueKey(couponId);
         redisTemplate.opsForZSet().remove(key, String.valueOf(userId));
     }
 
+
+    public void removeUserFromFailedQueue(Long couponId, Long userId) {
+        String key = buildFailedKey(couponId);
+        redisTemplate.opsForZSet().remove(key, String.valueOf(userId));
+    }
+
+
     public void addToIssuedSet(Long couponId, Long userId) {
         String key = buildIssuedKey(couponId);
         redisTemplate.opsForZSet().add(key, String.valueOf(userId), System.currentTimeMillis());
     }
+
+
+    public void addToFailedSet(Long couponId, Long userId) {
+        String key = buildFailedKey(couponId);
+        redisTemplate.opsForZSet().add(key, String.valueOf(userId), System.currentTimeMillis());
+    }
+
 
     public boolean isAlreadyIssued(Long couponId, Long userId) {
         String key = buildIssuedKey(couponId);
@@ -59,6 +94,7 @@ public class CouponQueueRepository {
 
         return score != null;
     }
+
 
     public Long getQueueSize(Long couponId) {
         String key = buildQueueKey(couponId);

--- a/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/repository/CouponQueueRepository.java
@@ -14,6 +14,7 @@ public class CouponQueueRepository {
     private static final String WAITING_KEY_PREFIX = "coupon:waiting:";
     private static final String ISSUED_KEY_PREFIX = "coupon:issued:";
 
+
     public String buildQueueKey(Long couponId) {
         return WAITING_KEY_PREFIX + couponId;
     }
@@ -50,7 +51,11 @@ public class CouponQueueRepository {
 
     public boolean isAlreadyIssued(Long couponId, Long userId) {
         String key = buildIssuedKey(couponId);
-        return redisTemplate.opsForZSet().score(key, String.valueOf(userId)) != null;
+        Double score = redisTemplate.opsForZSet().score(key, String.valueOf(userId));
+
+        System.out.println("check issued - userId: " + userId + ", score: " + score);
+
+        return score != null;
     }
 
     public Long getQueueSize(Long couponId) {

--- a/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
@@ -3,6 +3,7 @@ package couponToy.CouponToyProject.queue.scheduler;
 import couponToy.CouponToyProject.CouponIssue.service.IssueCouponService;
 import couponToy.CouponToyProject.global.exception.CouponSoldOutException;
 import couponToy.CouponToyProject.queue.repository.CouponQueueRepository;
+import couponToy.CouponToyProject.queue.service.CouponQueueSchedulerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.RedisConnection;
@@ -25,8 +26,8 @@ import java.util.Set;
 public class CouponQueueScheduler {
 
     private final CouponQueueRepository couponQueueRepository;
-    private final IssueCouponService issueCouponService;
     private final StringRedisTemplate redisTemplate;
+    private final CouponQueueSchedulerService queueSchedulerService;
 
     // 한 번에 처리할 사용자 수 (예: 상위 5명)
     private static final long PROCESS_COUNT = 5;
@@ -92,7 +93,7 @@ public class CouponQueueScheduler {
         for (String userIdStr : waitingUserIds) {
             try {
                 Long userId = Long.valueOf(userIdStr);
-                issueCouponService.issueFromQueue(couponId, userId);
+                queueSchedulerService.issueFromQueue(couponId, userId);
 
                 couponQueueRepository.removeUserFromQueue(couponId, userId);
                 couponQueueRepository.addToIssuedSet(couponId, userId);

--- a/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
@@ -1,0 +1,120 @@
+package couponToy.CouponToyProject.queue.scheduler;
+
+import couponToy.CouponToyProject.CouponIssue.service.IssueCouponService;
+import couponToy.CouponToyProject.queue.repository.CouponQueueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@EnableScheduling
+@Component
+@RequiredArgsConstructor
+public class CouponQueueScheduler {
+
+    private final CouponQueueRepository couponQueueRepository;
+    private final IssueCouponService issueCouponService;
+    private final StringRedisTemplate redisTemplate;
+
+    // 한 번에 처리할 사용자 수 (예: 상위 5명)
+    private static final long PROCESS_COUNT = 5;
+    private static final String WAITING_KEY_PREFIX = "coupon:waiting:";
+
+    /**
+     * 1초마다 실행하여, Redis에 저장된 모든 coupon:waiting:* 키를 동적으로 조회한 후,
+     * 각 쿠폰 대기열에 대해 상위 PROCESS_COUNT명의 사용자에 대해 발급 처리를 시도한다.
+     */
+    @Scheduled(fixedDelay = 1000)
+    @Transactional
+    public void processQueue() {
+        Set<String> waitingKeys = getAllWaitingQueueKeys();
+        if (waitingKeys.isEmpty()) {
+            return;
+        }
+        for (String key : waitingKeys) {
+            Long couponId = extractCouponIdFromKey(key);
+            processQueueForCoupon(couponId);
+        }
+    }
+
+    /**
+     * SCAN 명령어를 사용해 모든 "coupon:waiting:*" 키를 조회한다.
+     */
+    private Set<String> getAllWaitingQueueKeys() {
+        Set<String> keys = new HashSet<>();
+        RedisConnectionFactory factory = redisTemplate.getConnectionFactory();
+        if (factory == null) {
+            return keys;
+        }
+        try (RedisConnection connection = factory.getConnection()) {
+            ScanOptions scanOptions = ScanOptions.scanOptions()
+                    .match(WAITING_KEY_PREFIX + "*")
+                    .count(1000)
+                    .build();
+            Cursor<byte[]> cursor = connection.scan(scanOptions);
+            while (cursor.hasNext()) {
+                String key = new String(cursor.next(), StandardCharsets.UTF_8);
+                keys.add(key);
+            }
+        } catch (Exception ex) {
+            log.error("대기열 키 조회 중 오류 발생", ex);
+        }
+        return keys;
+    }
+
+    /**
+     * 대기열 키("coupon:waiting:{couponId}")에서 couponId를 추출한다.
+     */
+    private Long extractCouponIdFromKey(String key) {
+        String idPart = key.substring(WAITING_KEY_PREFIX.length());
+        return Long.valueOf(idPart);
+    }
+
+    /**
+     * 특정 쿠폰의 대기열에서 상위 PROCESS_COUNT명의 사용자를 조회하여 발급 처리를 시도한다.
+     */
+    private void processQueueForCoupon(Long couponId) {
+        Set<String> waitingUserIds = couponQueueRepository.getTopNUsers(couponId, PROCESS_COUNT);
+        if (waitingUserIds == null || waitingUserIds.isEmpty()) {
+            return;
+        }
+        for (String userIdStr : waitingUserIds) {
+            try {
+                Long userId = Long.valueOf(userIdStr);
+                boolean issued = issueCouponService.issueFromQueue(couponId, userId);
+                if (issued) {
+                    couponQueueRepository.removeUserFromQueue(couponId, userId);
+                    couponQueueRepository.addToIssuedSet(couponId, userId);
+                    log.info("쿠폰 발급 완료 - couponId: {}, userId: {}", couponId, userId);
+                } else {
+                    // 발급 수량이 소진된 경우, 대기열을 전체 삭제(또는 다른 처리를 수행)
+                    log.info("쿠폰 발급 수량 소진 - couponId: {}", couponId);
+                    clearWaitingQueue(couponId);
+                    break;
+                }
+            } catch (Exception e) {
+                log.error("쿠폰 발급 처리 중 오류 발생 - couponId: {}, userId: {}", couponId, userIdStr, e);
+            }
+        }
+    }
+
+    /**
+     * 특정 쿠폰의 대기열 전체를 삭제한다.
+     */
+    private void clearWaitingQueue(Long couponId) {
+        String key = WAITING_KEY_PREFIX + couponId;
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
@@ -38,7 +38,7 @@ public class CouponQueueScheduler {
      * 1초마다 실행하여, Redis에 저장된 모든 coupon:waiting:* 키를 동적으로 조회한 후,
      * 각 쿠폰 대기열에 대해 상위 PROCESS_COUNT명의 사용자에 대해 발급 처리를 시도한다.
      */
-    @Scheduled(fixedDelay = 500)
+    @Scheduled(fixedDelay = 1000)
     public void processQueue() {
         Set<String> waitingKeys = getAllQueueKeys(WAITING_KEY_PREFIX);
 

--- a/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
@@ -3,6 +3,7 @@ package couponToy.CouponToyProject.queue.scheduler;
 import couponToy.CouponToyProject.global.exception.CouponSoldOutException;
 import couponToy.CouponToyProject.queue.repository.CouponQueueRepository;
 import couponToy.CouponToyProject.queue.service.CouponQueueSchedulerService;
+import couponToy.CouponToyProject.queue.util.RedisKeyUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.RedisConnection;
@@ -162,8 +163,7 @@ public class CouponQueueScheduler {
      * 대기열 키("coupon:waiting:{couponId}")에서 couponId를 추출한다.
      */
     private Long extractCouponIdFromKey(String prefix, String key) {
-        String idPart = key.substring(prefix.length());
-        return Long.valueOf(idPart);
+        return RedisKeyUtils.extractCouponIdFromKey(prefix, key);
     }
 
 
@@ -171,7 +171,9 @@ public class CouponQueueScheduler {
      * 특정 쿠폰의 대기열 전체를 삭제한다.
      */
     private void clearQueue(String prefix, Long couponId) {
-        String key = prefix + couponId;
+        String key = prefix.equals(RedisKeyUtils.WAITING_KEY_PREFIX) ?
+                RedisKeyUtils.buildQueueKey(couponId)
+                : RedisKeyUtils.buildFailedKey(couponId);
         redisTemplate.delete(key);
     }
 }

--- a/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/scheduler/CouponQueueScheduler.java
@@ -38,7 +38,7 @@ public class CouponQueueScheduler {
      * 1초마다 실행하여, Redis에 저장된 모든 coupon:waiting:* 키를 동적으로 조회한 후,
      * 각 쿠폰 대기열에 대해 상위 PROCESS_COUNT명의 사용자에 대해 발급 처리를 시도한다.
      */
-    @Scheduled(fixedDelay = 1000)
+    @Scheduled(fixedDelay = 500)
     public void processQueue() {
         Set<String> waitingKeys = getAllQueueKeys(WAITING_KEY_PREFIX);
 
@@ -51,7 +51,7 @@ public class CouponQueueScheduler {
         }
     }
 
-    @Scheduled(fixedDelay = 1000)
+    @Scheduled(fixedDelay = 500)
     public void processFailedQueue() {
         Set<String> failedKeys = getAllQueueKeys(FAILED_KEY_PREFIX);
 

--- a/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueSchedulerService.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueSchedulerService.java
@@ -1,0 +1,40 @@
+package couponToy.CouponToyProject.queue.service;
+
+import couponToy.CouponToyProject.Coupon.model.Coupon;
+import couponToy.CouponToyProject.Coupon.repository.CouponRepository;
+import couponToy.CouponToyProject.CouponIssue.model.IssueCoupon;
+import couponToy.CouponToyProject.CouponIssue.repository.IssueCouponRepository;
+import couponToy.CouponToyProject.global.constant.ErrorCode;
+import couponToy.CouponToyProject.global.exception.CouponNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponQueueSchedulerService {
+
+    private final CouponRepository couponRepository;
+    private final IssueCouponRepository issueCouponRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void issueFromQueue(Long couponId, Long userId) {
+        // 1. 쿠폰을 비관적 락으로 조회
+        Coupon coupon = couponRepository.findByCouponIdForUpdate(couponId)
+                .orElseThrow(() -> new CouponNotFoundException(ErrorCode.NOT_FOUND_COUPON));
+
+        // 2. 발급 수량 초과 여부 확인 & 발급 수량 증가
+        coupon.increaseIssueAmount();
+
+        // 3. 발급 이력 저장
+        IssueCoupon issueCoupon = IssueCoupon.builder()
+                .memberId(userId)
+                .couponId(couponId)
+                .build();
+
+        issueCouponRepository.save(issueCoupon);
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueService.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueService.java
@@ -1,5 +1,7 @@
 package couponToy.CouponToyProject.queue.service;
 
+import couponToy.CouponToyProject.global.constant.ErrorCode;
+import couponToy.CouponToyProject.global.exception.IsAlreadyIssued;
 import couponToy.CouponToyProject.queue.repository.CouponQueueRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,9 +13,8 @@ public class CouponQueueService {
     private final CouponQueueRepository couponQueueRepository;
 
     public void registerUser(Long couponId, Long userId) {
-        if (!couponQueueRepository.isAlreadyIssued(couponId, userId)) {
-            couponQueueRepository.addToWaitingQueue(couponId, userId);
-        }
+        validatedNotIssued(couponId, userId);
+        couponQueueRepository.addToWaitingQueue(couponId, userId);
     }
 
     public Long getUserRank(Long couponId, Long userId) {
@@ -26,5 +27,11 @@ public class CouponQueueService {
 
     public boolean isAlreadyIssued(Long couponId, Long userId) {
         return couponQueueRepository.isAlreadyIssued(couponId, userId);
+    }
+
+    public void validatedNotIssued(Long couponId, Long userId) {
+        if (couponQueueRepository.isAlreadyIssued(couponId, userId)) {
+            throw new IsAlreadyIssued(ErrorCode.IS_ALREADY_ISSUED);
+        }
     }
 }

--- a/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueService.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueService.java
@@ -29,7 +29,7 @@ public class CouponQueueService {
         return couponQueueRepository.isAlreadyIssued(couponId, userId);
     }
 
-    public void validatedNotIssued(Long couponId, Long userId) {
+    private void validatedNotIssued(Long couponId, Long userId) {
         if (couponQueueRepository.isAlreadyIssued(couponId, userId)) {
             throw new IsAlreadyIssued(ErrorCode.IS_ALREADY_ISSUED);
         }

--- a/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueService.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/service/CouponQueueService.java
@@ -1,0 +1,30 @@
+package couponToy.CouponToyProject.queue.service;
+
+import couponToy.CouponToyProject.queue.repository.CouponQueueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponQueueService {
+
+    private final CouponQueueRepository couponQueueRepository;
+
+    public void registerUser(Long couponId, Long userId) {
+        if (!couponQueueRepository.isAlreadyIssued(couponId, userId)) {
+            couponQueueRepository.addToWaitingQueue(couponId, userId);
+        }
+    }
+
+    public Long getUserRank(Long couponId, Long userId) {
+        return couponQueueRepository.getUserRank(couponId, userId);
+    }
+
+    public Long getQueueSize(Long couponId) {
+        return couponQueueRepository.getQueueSize(couponId);
+    }
+
+    public boolean isAlreadyIssued(Long couponId, Long userId) {
+        return couponQueueRepository.isAlreadyIssued(couponId, userId);
+    }
+}

--- a/src/main/java/couponToy/CouponToyProject/queue/util/RedisKeyUtils.java
+++ b/src/main/java/couponToy/CouponToyProject/queue/util/RedisKeyUtils.java
@@ -1,0 +1,36 @@
+package couponToy.CouponToyProject.queue.util;
+
+
+public final class RedisKeyUtils {
+
+    public static final String WAITING_KEY_PREFIX = "coupon:waiting:";
+    public static final String ISSUED_KEY_PREFIX = "coupon:issued:";
+    public static final String FAILED_KEY_PREFIX = "coupon:failed:";
+
+
+    private RedisKeyUtils() {
+        throw new UnsupportedOperationException("유틸리티 서비스는 인스턴스화 할 수 없습니다.");
+    }
+
+    public static String buildQueueKey(Long couponId) {
+        return WAITING_KEY_PREFIX + couponId;
+    }
+
+    public static String buildIssuedKey(Long couponId) {
+        return ISSUED_KEY_PREFIX + couponId;
+    }
+
+    public static String buildFailedKey(Long couponId) {
+        return FAILED_KEY_PREFIX + couponId;
+    }
+
+
+    public static Long extractCouponIdFromKey(String prefix, String key) {
+        if (!key.startsWith(prefix)) {
+            throw new IllegalArgumentException("키(" + key + ")는 접두어(" + prefix + ")로 시작하지 않습니다.");
+        }
+
+        String idPart = key.substring(prefix.length());
+        return Long.valueOf(idPart);
+    }
+}

--- a/src/test/java/couponToy/CouponToyProject/CouponQueue/service/CouponQueueServiceTest.java
+++ b/src/test/java/couponToy/CouponToyProject/CouponQueue/service/CouponQueueServiceTest.java
@@ -1,0 +1,342 @@
+package couponToy.CouponToyProject.CouponQueue.service;
+
+import couponToy.CouponToyProject.Coupon.dto.CouponCreateRequest;
+import couponToy.CouponToyProject.Coupon.model.Coupon;
+import couponToy.CouponToyProject.Coupon.repository.CouponRepository;
+import couponToy.CouponToyProject.Coupon.service.CouponService;
+import couponToy.CouponToyProject.CouponIssue.repository.IssueCouponRepository;
+import couponToy.CouponToyProject.Member.dto.MemberSignUpRequest;
+import couponToy.CouponToyProject.Member.dto.MemberSignUpResponse;
+import couponToy.CouponToyProject.Member.model.Member;
+import couponToy.CouponToyProject.Member.repository.MemberRepository;
+import couponToy.CouponToyProject.Member.service.MemberService;
+import couponToy.CouponToyProject.global.security.MemberDetails;
+import couponToy.CouponToyProject.queue.repository.CouponQueueRepository;
+import couponToy.CouponToyProject.queue.service.CouponQueueService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class CouponQueueServiceTest {
+
+    @Autowired
+    private CouponQueueService couponQueueService;
+
+    @Autowired
+    private CouponQueueRepository couponQueueRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private IssueCouponRepository issueCouponRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+
+    private Coupon createTestCoupon(int totalCount) {
+        CouponCreateRequest request = new CouponCreateRequest("RedisTestCoupon", totalCount);
+        return couponRepository.findById(couponService.createCoupon(request).getCouponId())
+                .orElseThrow();
+    }
+
+    private Member createTestMember() {
+        MemberSignUpRequest signUpRequest = MemberSignUpRequest.builder()
+                .email("test@example.com")
+                .password("test1234!@")
+                .name("레디스테스트유저")
+                .build();
+
+        MemberSignUpResponse createdMember = memberService.signUpMember(signUpRequest);
+        Member member = memberRepository.findById(createdMember.getMemberId()).orElseThrow();
+
+        // Security Context 설정
+        MemberDetails memberDetails = MemberDetails.create(member);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                memberDetails, null, memberDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return member;
+    }
+
+    private Member createMultiTestMember(int index) {
+        MemberSignUpRequest signUpRequest = MemberSignUpRequest.builder()
+                .email("test" + index + "@example.com") // 인덱스로 유니크 처리
+                .password("test1234!@")
+                .name("대기열테스트유저" + index)
+                .build();
+
+        MemberSignUpResponse createdMember = memberService.signUpMember(signUpRequest);
+        Member member = memberRepository.findById(createdMember.getMemberId()).orElseThrow();
+
+        // Security Context 설정
+        MemberDetails memberDetails = MemberDetails.create(member);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                memberDetails, null, memberDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return member;
+    }
+
+    private void clearRedis(Long couponId) {
+        redisTemplate.delete("coupon:waiting:" + couponId);
+        redisTemplate.delete("coupon:issued:" + couponId);
+    }
+
+    @AfterEach
+    void clearRedisAll() {
+        redisTemplate.delete(redisTemplate.keys("coupon:*"));
+    }
+
+//    @AfterEach
+//    void resetDatabase() throws Exception {
+//        try (Connection conn = dataSource.getConnection();
+//             Statement stmt = conn.createStatement()) {
+//
+//            stmt.execute("SET FOREIGN_KEY_CHECKS = 0");
+//            stmt.execute("TRUNCATE TABLE coupon_issues");
+//            stmt.execute("TRUNCATE TABLE coupons");
+//            stmt.execute("TRUNCATE TABLE members");
+//            stmt.execute("ALTER TABLE coupon_issues AUTO_INCREMENT = 1");
+//            stmt.execute("ALTER TABLE coupons AUTO_INCREMENT = 1");
+//            stmt.execute("ALTER TABLE members AUTO_INCREMENT = 1");
+//            stmt.execute("SET FOREIGN_KEY_CHECKS = 1");
+//        }
+//    }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자 Redis 대기열 등록 및 순번 확인")
+    void addToQueueAndCheckRank() {
+        // given
+        Coupon coupon = createTestCoupon(30);
+        Member member = createTestMember();
+
+        Long couponId = coupon.getCouponId();
+        Long userId = member.getMemberId();
+        clearRedis(couponId);
+
+        couponQueueService.registerUser(couponId, userId);
+        Long rank = couponQueueService.getUserRank(couponId, userId);
+
+        System.out.println("couponId = " + couponId);
+        System.out.println("userId = " + userId);
+        System.out.println("rank = " + rank);
+
+        // then
+        assertThat(rank).isEqualTo(0L);
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("발급 완료된 사용자는 대기열에 등록되지 않음")
+    void alreadyIssuedUserIsSkipped() {
+        // given
+        Coupon coupon = createTestCoupon(30);
+        Member member = createTestMember();
+
+        Long couponId = coupon.getCouponId();
+        Long userId = member.getMemberId();
+        clearRedis(couponId);
+
+        couponQueueRepository.addToIssuedSet(couponId, userId);
+
+        // when
+        couponQueueService.registerUser(couponId, userId);
+        Long rank = couponQueueService.getUserRank(couponId, userId);
+
+        System.out.println("couponId = " + couponId);
+        System.out.println("userId = " + userId);
+        System.out.println("rank = " + rank);
+
+        // then
+        assertThat(rank).isNull();
+    }
+
+    @Test
+    @DisplayName("대기열 등록 후 대기열 사이즈 확인")
+    @Transactional
+    void checkQueueSize() {
+
+        // given
+        Coupon coupon = createTestCoupon(30);
+        Long couponId = coupon.getCouponId();
+        clearRedis(couponId);
+
+        for (int i = 0; i < 3; i++) {
+            Member member = createMultiTestMember(i);
+            Long userId = member.getMemberId();
+
+            couponQueueService.registerUser(couponId, userId);
+        }
+
+        Long size = couponQueueService.getQueueSize(couponId);
+
+        System.out.println("size = " + size);
+
+        // then
+        assertThat(size).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("멀티 스레드 환경에서 대기열 등록 테스트")
+    void concurrentQueueRegistrationTest() throws InterruptedException {
+
+        // given
+        int threadCount = 50;
+        int couponAmount = 10;
+
+        Coupon coupon = createTestCoupon(couponAmount);
+        Long couponId = coupon.getCouponId();
+        clearRedis(couponId);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            int index = i;
+            executorService.submit(() -> {
+                try {
+                    // 1. 회원 개별 생성
+                    Member member = createMultiTestMember(index);
+                    couponQueueService.registerUser(couponId, member.getMemberId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("발급 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드 작업 종료 대기
+
+        // then
+        Long queueSize = couponQueueService.getQueueSize(couponId);
+        System.out.println("successCount: " + successCount.get());
+        System.out.println("failCount: " + failCount.get());
+        System.out.println("queueSize: " + queueSize);
+
+        assertThat(queueSize).isEqualTo(threadCount);
+    }
+
+
+    @Test
+    @DisplayName("대기열 등록 후 스케줄러 발급 정상 처리")
+    void schedulerIssueFlowTest() throws InterruptedException {
+
+        // given
+        int userCount = 50;
+        int couponAmount = 10;
+
+        Coupon coupon = createTestCoupon(couponAmount);
+        Long couponId = coupon.getCouponId();
+        clearRedis(couponId);
+
+        for (int i = 0; i < userCount; i++) {
+            Member member = createMultiTestMember(i);
+            couponQueueService.registerUser(couponId, member.getMemberId());
+        }
+
+        // when: 스케줄러 실행 대기 (1~2초 사이 실행됨)
+        Thread.sleep(3000);
+
+        // then
+        long issuedCount = issueCouponRepository.countByCouponId(couponId);
+        Long redisIssuedSize = redisTemplate.opsForZSet().size("coupon:issued:" + couponId);
+
+        System.out.println("쿠폰 발급 수량 (DB): " + issuedCount);
+        System.out.println("쿠폰 발급 수량 (Redis): " + redisIssuedSize);
+
+        assertThat(issuedCount).isEqualTo(couponAmount);
+        assertThat(redisIssuedSize).isEqualTo((long) couponAmount);
+    }
+
+
+    @Test
+    @DisplayName("대기열 등록 후 스케줄러 발급 정상 처리")
+    void concurrentSchedulerIssueFlowTest() throws InterruptedException {
+
+        // given
+        int threadCount = 50;
+        int couponAmount = 10;
+
+        Coupon coupon = createTestCoupon(couponAmount);
+        Long couponId = coupon.getCouponId();
+        clearRedis(couponId);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            int index = i;
+            executorService.submit(() -> {
+                try {
+                    // 1. 회원 개별 생성
+                    Member member = createMultiTestMember(index);
+                    couponQueueService.registerUser(couponId, member.getMemberId());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.out.println("발급 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        Thread.sleep(3000);
+        latch.await(); // 모든 스레드 작업 종료 대기
+
+        // then
+        long issuedCount = issueCouponRepository.countByCouponId(couponId);
+        Long redisIssuedSize = redisTemplate.opsForZSet().size("coupon:issued:" + couponId);
+
+        System.out.println("쿠폰 발급 수량 (DB): " + issuedCount);
+        System.out.println("쿠폰 발급 수량 (Redis): " + redisIssuedSize);
+
+        assertThat(issuedCount).isEqualTo(couponAmount);
+        assertThat(redisIssuedSize).isEqualTo((long) couponAmount);
+    }
+}

--- a/src/test/java/couponToy/CouponToyProject/CouponQueue/service/CouponQueueServiceTest.java
+++ b/src/test/java/couponToy/CouponToyProject/CouponQueue/service/CouponQueueServiceTest.java
@@ -275,7 +275,7 @@ public class CouponQueueServiceTest {
             couponQueueService.registerUser(couponId, member.getMemberId());
         }
 
-        // when: 스케줄러 실행 대기 (1~2초 사이 실행됨)
+        // when
         Thread.sleep(3000);
 
         // then
@@ -291,12 +291,12 @@ public class CouponQueueServiceTest {
 
 
     @Test
-    @DisplayName("대기열 등록 후 스케줄러 발급 정상 처리")
-    void concurrentSchedulerIssueFlowTest() throws InterruptedException {
+    @DisplayName("멀티 스레드 환경 쿠폰 발급 테스트")
+    void concurrentQueueIssueTest() throws InterruptedException {
 
         // given
-        int threadCount = 50;
-        int couponAmount = 10;
+        int threadCount = 100;
+        int couponAmount = 70;
 
         Coupon coupon = createTestCoupon(couponAmount);
         Long couponId = coupon.getCouponId();
@@ -326,7 +326,7 @@ public class CouponQueueServiceTest {
             });
         }
 
-        Thread.sleep(3000);
+        Thread.sleep(10000);
         latch.await(); // 모든 스레드 작업 종료 대기
 
         // then
@@ -338,5 +338,18 @@ public class CouponQueueServiceTest {
 
         assertThat(issuedCount).isEqualTo(couponAmount);
         assertThat(redisIssuedSize).isEqualTo((long) couponAmount);
+    }
+
+
+    @Test
+    @DisplayName("목업 유저 생성")
+    void makeMultiUser() throws InterruptedException {
+
+        // given
+        int userCount = 1000;
+
+        for (int i = 0; i < userCount; i++) {
+            Member member = createMultiTestMember(i);
+        }
     }
 }


### PR DESCRIPTION
## 작업 요약
- Redis sorted set을 활용한 대기열 구현
## Issue Link
#25 
## 문제점 및 어려움
- 사용자가 쿠폰 발급 재요청 시 처리 방법 고민 
## 해결 방안
- 대기열 페이지로 보낸 후 자신의 현재 번호와 남은 대기열을 보여준다.
- 쿠폰 발급 재 요청 시 기존 대기열 정보는 삭제하고 다시 등록한다. 
-> 하나 선택해서 리팩토링 해야 함
## Reference
- https://www.youtube.com/watch?v=MTSn93rNPPE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Redis 기반의 쿠폰 대기열 시스템과 자동 처리 기능이 추가되어, 사용자들이 대기 순위를 확인하고 쿠폰 등록을 할 수 있게 되었습니다.
  - 중복 쿠폰 발급을 방지하는 검증 기능이 강화되었습니다.
  - 새로운 오류 코드 `IS_ALREADY_ISSUED`가 추가되어 이미 쿠폰을 발급받은 사용자를 처리할 수 있게 되었습니다.
  - Redis를 통한 쿠폰 발급 및 대기열 관리 기능이 추가되었습니다.
  - 쿠폰 발급을 위한 새로운 서비스 및 스케줄러가 도입되었습니다.

- **버그 수정**
  - 사용하지 않는 필드와 메서드가 제거되어 코드가 간소화되었습니다.

- **테스트**
  - 쿠폰 대기열 관리, 발급 처리 및 동시성 상황을 포괄하는 종합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->